### PR TITLE
Add Workout Tracker site: pages, images, styles, and JS renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-Visit http://lostground97.github.io/ to know more about me.
+# Workout Tracker
+
+Simple workout planner built with plain HTML, CSS, and JavaScript.
+
+## Pages
+- `index.html`: choose your workout day.
+- `chest.html`, `back.html`, `shoulders.html`, `legs.html`, `arms.html`: one page per muscle group with exercise lists.
+
+## Images
+- Static local exercise images are stored in `images/exercises`.
+- Each exercise card shows 3 local static `.svg` images.

--- a/arms.html
+++ b/arms.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Arms Workout</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-muscle="arms">
+    <main class="container">
+      <header class="workout-header">
+        <h1 id="workoutTitle"></h1>
+        <a class="back-link" href="index.html">← Back to day selector</a>
+      </header>
+
+      <section id="exerciseList" class="exercise-list"></section>
+      <p id="note" class="note"></p>
+    </main>
+    <script src="workout.js"></script>
+  </body>
+</html>

--- a/back.html
+++ b/back.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Back Workout</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-muscle="back">
+    <main class="container">
+      <header class="workout-header">
+        <h1 id="workoutTitle"></h1>
+        <a class="back-link" href="index.html">← Back to day selector</a>
+      </header>
+
+      <section id="exerciseList" class="exercise-list"></section>
+      <p id="note" class="note"></p>
+    </main>
+    <script src="workout.js"></script>
+  </body>
+</html>

--- a/chest.html
+++ b/chest.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chest Workout</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-muscle="chest">
+    <main class="container">
+      <header class="workout-header">
+        <h1 id="workoutTitle"></h1>
+        <a class="back-link" href="index.html">← Back to day selector</a>
+      </header>
+
+      <section id="exerciseList" class="exercise-list"></section>
+      <p id="note" class="note"></p>
+    </main>
+    <script src="workout.js"></script>
+  </body>
+</html>

--- a/images/exercises/arms-cable-overhead-extension-1.svg
+++ b/images/exercises/arms-cable-overhead-extension-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Cable Overhead Extension</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/arms-cable-overhead-extension-2.svg
+++ b/images/exercises/arms-cable-overhead-extension-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Cable Overhead Extension</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/arms-cable-overhead-extension-3.svg
+++ b/images/exercises/arms-cable-overhead-extension-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Cable Overhead Extension</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/arms-cable-pushdown-1.svg
+++ b/images/exercises/arms-cable-pushdown-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Cable Pushdown</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/arms-cable-pushdown-2.svg
+++ b/images/exercises/arms-cable-pushdown-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Cable Pushdown</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/arms-cable-pushdown-3.svg
+++ b/images/exercises/arms-cable-pushdown-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Cable Pushdown</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/arms-ez-bar-curl-1.svg
+++ b/images/exercises/arms-ez-bar-curl-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">EZ Bar Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/arms-ez-bar-curl-2.svg
+++ b/images/exercises/arms-ez-bar-curl-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">EZ Bar Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/arms-ez-bar-curl-3.svg
+++ b/images/exercises/arms-ez-bar-curl-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">EZ Bar Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/arms-hammer-curl-1.svg
+++ b/images/exercises/arms-hammer-curl-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Hammer Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/arms-hammer-curl-2.svg
+++ b/images/exercises/arms-hammer-curl-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Hammer Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/arms-hammer-curl-3.svg
+++ b/images/exercises/arms-hammer-curl-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Hammer Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/arms-preacher-curl-1.svg
+++ b/images/exercises/arms-preacher-curl-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Preacher Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/arms-preacher-curl-2.svg
+++ b/images/exercises/arms-preacher-curl-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Preacher Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/arms-preacher-curl-3.svg
+++ b/images/exercises/arms-preacher-curl-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Preacher Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/arms-single-arm-overhead-dumbbell-french-press-1.svg
+++ b/images/exercises/arms-single-arm-overhead-dumbbell-french-press-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Single-Arm Overhead Dumbbell French Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/arms-single-arm-overhead-dumbbell-french-press-2.svg
+++ b/images/exercises/arms-single-arm-overhead-dumbbell-french-press-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Single-Arm Overhead Dumbbell French Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/arms-single-arm-overhead-dumbbell-french-press-3.svg
+++ b/images/exercises/arms-single-arm-overhead-dumbbell-french-press-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Arms Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Single-Arm Overhead Dumbbell French Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/back-barbell-row-1.svg
+++ b/images/exercises/back-barbell-row-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Barbell Row</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/back-barbell-row-2.svg
+++ b/images/exercises/back-barbell-row-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Barbell Row</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/back-barbell-row-3.svg
+++ b/images/exercises/back-barbell-row-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Barbell Row</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/back-deadlift-1.svg
+++ b/images/exercises/back-deadlift-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Deadlift</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/back-deadlift-2.svg
+++ b/images/exercises/back-deadlift-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Deadlift</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/back-deadlift-3.svg
+++ b/images/exercises/back-deadlift-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Deadlift</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/back-lat-pulldown-1.svg
+++ b/images/exercises/back-lat-pulldown-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Lat Pulldown</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/back-lat-pulldown-2.svg
+++ b/images/exercises/back-lat-pulldown-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Lat Pulldown</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/back-lat-pulldown-3.svg
+++ b/images/exercises/back-lat-pulldown-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Lat Pulldown</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/back-rope-face-pull-1.svg
+++ b/images/exercises/back-rope-face-pull-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Rope Face Pull</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/back-rope-face-pull-2.svg
+++ b/images/exercises/back-rope-face-pull-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Rope Face Pull</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/back-rope-face-pull-3.svg
+++ b/images/exercises/back-rope-face-pull-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Rope Face Pull</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/back-seated-cable-row-1.svg
+++ b/images/exercises/back-seated-cable-row-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Seated Cable Row</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/back-seated-cable-row-2.svg
+++ b/images/exercises/back-seated-cable-row-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Seated Cable Row</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/back-seated-cable-row-3.svg
+++ b/images/exercises/back-seated-cable-row-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Back Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Seated Cable Row</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/chest-cable-crossover-1.svg
+++ b/images/exercises/chest-cable-crossover-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Cable Crossover</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/chest-cable-crossover-2.svg
+++ b/images/exercises/chest-cable-crossover-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Cable Crossover</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/chest-cable-crossover-3.svg
+++ b/images/exercises/chest-cable-crossover-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Cable Crossover</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/chest-chest-press-machine-1.svg
+++ b/images/exercises/chest-chest-press-machine-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Chest Press Machine</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/chest-chest-press-machine-2.svg
+++ b/images/exercises/chest-chest-press-machine-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Chest Press Machine</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/chest-chest-press-machine-3.svg
+++ b/images/exercises/chest-chest-press-machine-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Chest Press Machine</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/chest-dumbbell-bench-press-1.svg
+++ b/images/exercises/chest-dumbbell-bench-press-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Dumbbell Bench Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/chest-dumbbell-bench-press-2.svg
+++ b/images/exercises/chest-dumbbell-bench-press-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Dumbbell Bench Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/chest-dumbbell-bench-press-3.svg
+++ b/images/exercises/chest-dumbbell-bench-press-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Dumbbell Bench Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/chest-incline-dumbbell-press-1.svg
+++ b/images/exercises/chest-incline-dumbbell-press-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Incline Dumbbell Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/chest-incline-dumbbell-press-2.svg
+++ b/images/exercises/chest-incline-dumbbell-press-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Incline Dumbbell Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/chest-incline-dumbbell-press-3.svg
+++ b/images/exercises/chest-incline-dumbbell-press-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Chest Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Incline Dumbbell Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/legs-barbell-back-squats-1.svg
+++ b/images/exercises/legs-barbell-back-squats-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Barbell Back Squats</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/legs-barbell-back-squats-2.svg
+++ b/images/exercises/legs-barbell-back-squats-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Barbell Back Squats</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/legs-barbell-back-squats-3.svg
+++ b/images/exercises/legs-barbell-back-squats-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Barbell Back Squats</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/legs-goblet-squats-1.svg
+++ b/images/exercises/legs-goblet-squats-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Goblet Squats</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/legs-goblet-squats-2.svg
+++ b/images/exercises/legs-goblet-squats-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Goblet Squats</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/legs-goblet-squats-3.svg
+++ b/images/exercises/legs-goblet-squats-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Goblet Squats</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/legs-leg-curl-1.svg
+++ b/images/exercises/legs-leg-curl-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Leg Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/legs-leg-curl-2.svg
+++ b/images/exercises/legs-leg-curl-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Leg Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/legs-leg-curl-3.svg
+++ b/images/exercises/legs-leg-curl-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Leg Curl</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/legs-leg-extension-1.svg
+++ b/images/exercises/legs-leg-extension-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Leg Extension</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/legs-leg-extension-2.svg
+++ b/images/exercises/legs-leg-extension-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Leg Extension</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/legs-leg-extension-3.svg
+++ b/images/exercises/legs-leg-extension-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Leg Extension</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/legs-leg-press-1.svg
+++ b/images/exercises/legs-leg-press-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Leg Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/legs-leg-press-2.svg
+++ b/images/exercises/legs-leg-press-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Leg Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/legs-leg-press-3.svg
+++ b/images/exercises/legs-leg-press-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Legs Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Leg Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/shoulders-lateral-raises-very-important-for-shoulder-width-1.svg
+++ b/images/exercises/shoulders-lateral-raises-very-important-for-shoulder-width-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Lateral Raises (very important for shoulder width)</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/shoulders-lateral-raises-very-important-for-shoulder-width-2.svg
+++ b/images/exercises/shoulders-lateral-raises-very-important-for-shoulder-width-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Lateral Raises (very important for shoulder width)</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/shoulders-lateral-raises-very-important-for-shoulder-width-3.svg
+++ b/images/exercises/shoulders-lateral-raises-very-important-for-shoulder-width-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Lateral Raises (very important for shoulder width)</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/shoulders-machine-shoulder-press-1.svg
+++ b/images/exercises/shoulders-machine-shoulder-press-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Machine Shoulder Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/shoulders-machine-shoulder-press-2.svg
+++ b/images/exercises/shoulders-machine-shoulder-press-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Machine Shoulder Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/shoulders-machine-shoulder-press-3.svg
+++ b/images/exercises/shoulders-machine-shoulder-press-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Machine Shoulder Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/shoulders-overhead-dumbbell-press-1.svg
+++ b/images/exercises/shoulders-overhead-dumbbell-press-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Overhead Dumbbell Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/shoulders-overhead-dumbbell-press-2.svg
+++ b/images/exercises/shoulders-overhead-dumbbell-press-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Overhead Dumbbell Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/shoulders-overhead-dumbbell-press-3.svg
+++ b/images/exercises/shoulders-overhead-dumbbell-press-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Overhead Dumbbell Press</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/shoulders-rear-delt-fly-face-pull-1.svg
+++ b/images/exercises/shoulders-rear-delt-fly-face-pull-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Rear Delt Fly / Face Pull</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/shoulders-rear-delt-fly-face-pull-2.svg
+++ b/images/exercises/shoulders-rear-delt-fly-face-pull-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Rear Delt Fly / Face Pull</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/shoulders-rear-delt-fly-face-pull-3.svg
+++ b/images/exercises/shoulders-rear-delt-fly-face-pull-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Rear Delt Fly / Face Pull</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/images/exercises/shoulders-upright-rows-1.svg
+++ b/images/exercises/shoulders-upright-rows-1.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#1e3a8a"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Upright Rows</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 1 / 3</text>
+</svg>

--- a/images/exercises/shoulders-upright-rows-2.svg
+++ b/images/exercises/shoulders-upright-rows-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#166534"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Upright Rows</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 2 / 3</text>
+</svg>

--- a/images/exercises/shoulders-upright-rows-3.svg
+++ b/images/exercises/shoulders-upright-rows-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480" viewBox="0 0 640 480">
+  <rect width="640" height="480" fill="#7c2d12"/>
+  <rect x="20" y="20" width="600" height="440" fill="none" stroke="#e2e8f0" stroke-width="4" rx="16"/>
+  <text x="320" y="200" text-anchor="middle" fill="#e2e8f0" font-size="34" font-family="Arial" font-weight="700">Shoulders Day</text>
+  <text x="320" y="255" text-anchor="middle" fill="#f8fafc" font-size="28" font-family="Arial">Upright Rows</text>
+  <text x="320" y="315" text-anchor="middle" fill="#93c5fd" font-size="22" font-family="Arial">Static image 3 / 3</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,91 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <title>Rishabh Sethi</title>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
-  <link rel="stylesheet" href="index.css">
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
-  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
-  <style>
-    /* Set height of the grid so .sidenav can be 100% (adjust if needed) */
-<<<<<<< HEAD
-    
-=======
->>>>>>> 39b2f2dfbe64dc954365e4dd9f1daed3332c210d
-    /* Set gray background color and 100% height */
-    .sidenav {
-      background-color: #f1f1f1;
-      height: 100%;
-    }
-    
-    /* Set black background color, white text and some padding */
-    footer {
-      background-color: #555;
-      color: white;
-      padding: 15px;
-    }
-    
-    /* On small screens, set height to 'auto' for sidenav and grid */
-    @media screen and (max-width: 767px) {
-      .sidenav {
-        height: auto;
-        padding: 15px;
-      }
-      .row.content {height: auto;} 
-    }
-  </style>
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Workout Tracker</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="hero">
+        <h1>Workout Tracker</h1>
+        <p>Pick today’s workout day and instantly see your exercise plan.</p>
+      </header>
 
-<div class="container-fluid">
-  <div class="row content">
-    <div class="col-sm-3 sidenav">
-      <h2 id="head-text">Rishabh Sethi</h2>
-      <center>
-      <img src="16IT8061.jpg" id="head-image"/>
-      </center>
-      <ul class="nav nav-pills nav-stacked">
-        <li><a href="https://www.linkedin.com/in/rishabhsethi97" target="new">LinkedIn</a></li>
-        <li><a href="./resume.html" target="new">Resume</a></li>
-        <li><a href="http://codeforces.com/profile/not_so_cool_handle" target="new">Codeforces @not_so_cool_handle</a></li>
-        <li><a href="https://www.goodreads.com/lostground97" target="new">Goodreads @lostground97</a></li>
-        <li><a href="http://lostground25.wordpress.com/" target="new">My Writings @lostground97</a></li>
-      </ul><br>
-    </div>
-
-    <div class="col-sm-9">
-      <h2>Competitive Coder With A Reading Habit</h2>
-      <hr>
-      <p class="intro-text">
-        I am Rishabh Sethi currently working in <a href="https://en.wikipedia.org/wiki/Amazon_(company)" target="new">Amazon</a> as a Software Development Engineer. I studied Information Technology at <a href="https://nitdgp.ac.in/" target="new">National Institute Of Technology Durgapur</a> from 2016-2020. My major interest include sport coding and reading books at incredible speed.
-      </p>
-      <br>
-      <p class="intro-text">My past achievements and experiences are as follows</p>
-      <ul>
-        <li class="list-text">Worked as Software Developer at <a href="https://en.wikipedia.org/wiki/Wells_Fargo" target="new">Wells Fargo</a> from August 2020 to May 2021</li>
-        <li class="list-text">Represeted NIT Durgapur in ICPC Regionals in 2018 at Amritapuri and Kharagpur <a href="https://icpc.global/ICPCID/P5L76LC4KCWV" target="new"><i>(ICPC Profile)</i></a></li>
-        <li class="list-text">Worked as a Software Developer Intern at Expedia Group from May 2019 to July 2019</li>
-        <li class="list-text">Contest head at <a href="https://www.recursionnitd.in" target="new">RECursion</a> a non-profit society at NIT Durgapur meant for betterment of programming culture at NIT Durgapur</li>
-      </ul>
-      <br>
-      <p class="intro-text">I am trying to keep my Goodreads account fairly active. You can find about my readings <a href="https://www.goodreads.com/lostground97" target="new">@lostground97</a>. My reading list include :</p>
-      <ul>
-        <li class="list-text">All books by Yuval Noah Harari, Dan Brown and even most probably John Green</li>
-        <li class="list-text">In suspense genre I've read <i>Fight Club, Tell No One, Tell Me Your Dreams</i> and many more.</li>
-        <li class="list-text">Going for the self help books, I've read <i>Ikigai, Who moved my cheese, I moved your cheese</i> etc.</li>
-      </ul>
-      <br>
-      <p class="intro-text">I usually don't work on personal projects but I would someday like to create an <i>algorithm to read human fellings and provide specific song feedback depending on the day and various other factors.</i> I like reading papers on Neurological Aspects of Computer Science.</p>
-      <p class="intro-text">You can find me pretty active on Steam <a href="https://steamcommunity.com/id/lostground97/" target="new"><i>@lostground97</i></a>. Feel free to contact my if you need some reading recommendation or want to discuss some mind blowing idea. I'm up for anything from death of a star to what your handwriting has to say about you. <br><i>My email is : rishabhsethi [.] stark [@] gmail [.] com</i></p>
-    </div>
-  </div>
-</div>
-
-<footer class="container-fluid" id="footer">
-  <p>Last Updated : 07/05/2021</p>
-</footer>
-
-</body>
+      <section>
+        <h2 class="section-title">Choose Your Muscle Day</h2>
+        <div class="day-grid">
+          <a class="day-card" href="chest.html">Chest Day</a>
+          <a class="day-card" href="back.html">Back Day</a>
+          <a class="day-card" href="shoulders.html">Shoulders Day</a>
+          <a class="day-card" href="legs.html">Legs Day</a>
+          <a class="day-card" href="arms.html">Arms Day</a>
+        </div>
+      </section>
+    </main>
+  </body>
 </html>

--- a/legs.html
+++ b/legs.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Legs Workout</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-muscle="legs">
+    <main class="container">
+      <header class="workout-header">
+        <h1 id="workoutTitle"></h1>
+        <a class="back-link" href="index.html">← Back to day selector</a>
+      </header>
+
+      <section id="exerciseList" class="exercise-list"></section>
+      <p id="note" class="note"></p>
+    </main>
+    <script src="workout.js"></script>
+  </body>
+</html>

--- a/shoulders.html
+++ b/shoulders.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Shoulders Workout</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body data-muscle="shoulders">
+    <main class="container">
+      <header class="workout-header">
+        <h1 id="workoutTitle"></h1>
+        <a class="back-link" href="index.html">← Back to day selector</a>
+      </header>
+
+      <section id="exerciseList" class="exercise-list"></section>
+      <p id="note" class="note"></p>
+    </main>
+    <script src="workout.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,120 @@
+:root {
+  --bg: #0f172a;
+  --card: #1e293b;
+  --card-hover: #334155;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  background: linear-gradient(180deg, #020617, #0f172a);
+  color: var(--text);
+}
+
+.container {
+  width: min(1100px, 92%);
+  margin: 0 auto;
+  padding: 2rem 0 3rem;
+}
+
+.hero {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.hero h1 {
+  margin-bottom: 0.5rem;
+  font-size: clamp(2rem, 4vw, 3rem);
+}
+
+.hero p {
+  color: var(--muted);
+}
+
+.section-title {
+  margin-bottom: 1rem;
+}
+
+.day-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1rem;
+}
+
+.day-card {
+  display: grid;
+  place-items: center;
+  min-height: 120px;
+  border-radius: 16px;
+  background: var(--card);
+  color: var(--text);
+  text-decoration: none;
+  font-size: 1.1rem;
+  font-weight: 700;
+  border: 1px solid #475569;
+  transition: 0.2s ease;
+}
+
+.day-card:hover {
+  transform: translateY(-3px);
+  background: var(--card-hover);
+  border-color: var(--accent);
+}
+
+.workout-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.back-link {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.exercise-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.exercise-card {
+  background: var(--card);
+  border: 1px solid #475569;
+  border-radius: 14px;
+  padding: 1rem;
+}
+
+.exercise-card h3 {
+  margin-top: 0;
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.image-grid img {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: 10px;
+  border: 1px solid #64748b;
+}
+
+.note {
+  margin-top: 1rem;
+  color: #facc15;
+  font-weight: 700;
+}

--- a/workout.js
+++ b/workout.js
@@ -1,0 +1,90 @@
+const workoutData = {
+  chest: {
+    title: 'Chest Day',
+    exercises: [
+      'Dumbbell Bench Press',
+      'Incline Dumbbell Press',
+      'Chest Press Machine',
+      'Cable Crossover'
+    ],
+    note: 'Optional finisher: Push-ups'
+  },
+  back: {
+    title: 'Back Day',
+    exercises: ['Deadlift', 'Barbell Row', 'Lat Pulldown', 'Seated Cable Row', 'Rope Face Pull']
+  },
+  shoulders: {
+    title: 'Shoulders Day',
+    exercises: [
+      'Overhead Dumbbell Press',
+      'Machine Shoulder Press',
+      'Lateral Raises (very important for shoulder width)',
+      'Upright Rows',
+      'Rear Delt Fly / Face Pull'
+    ],
+    note: 'Front, side, and rear delts all covered.'
+  },
+  legs: {
+    title: 'Legs Day',
+    exercises: ['Barbell Back Squats', 'Leg Press', 'Leg Curl', 'Leg Extension', 'Goblet Squats']
+  },
+  arms: {
+    title: 'Arms Day',
+    exercises: [
+      'EZ Bar Curl',
+      'Preacher Curl',
+      'Hammer Curl',
+      'Cable Pushdown',
+      'Single-Arm Overhead Dumbbell French Press',
+      'Cable Overhead Extension'
+    ]
+  }
+};
+
+function slugify(value) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '');
+}
+
+function imagePath(muscle, exercise, index) {
+  return `images/exercises/${muscle}-${slugify(exercise)}-${index}.svg`;
+}
+
+function renderWorkout(muscle) {
+  const data = workoutData[muscle];
+  if (!data) return;
+
+  document.querySelector('#workoutTitle').textContent = data.title;
+  const list = document.querySelector('#exerciseList');
+
+  data.exercises.forEach((exercise) => {
+    const card = document.createElement('article');
+    card.className = 'exercise-card';
+
+    const title = document.createElement('h3');
+    title.textContent = exercise;
+
+    const images = document.createElement('div');
+    images.className = 'image-grid';
+
+    for (let i = 1; i <= 3; i += 1) {
+      const img = document.createElement('img');
+      img.src = imagePath(muscle, exercise, i);
+      img.alt = `${exercise} static demo ${i}`;
+      img.loading = 'lazy';
+      images.appendChild(img);
+    }
+
+    card.append(title, images);
+    list.appendChild(card);
+  });
+
+  if (data.note) {
+    const note = document.querySelector('#note');
+    note.textContent = data.note;
+  }
+}
+
+renderWorkout(document.body.dataset.muscle);


### PR DESCRIPTION
### Motivation
- Replace a personal homepage with a small single-page-ish Workout Tracker to choose muscle days and view exercise plans and images.
- Provide local static SVG assets so each exercise card can show three static demo images without external dependencies.

### Description
- Add a new UI and layout: `index.html` (day selector) and per-muscle pages `chest.html`, `back.html`, `shoulders.html`, `legs.html`, and `arms.html` that use `data-muscle` to drive rendering.
- Add `workout.js` that contains `workoutData`, a `slugify` helper, `imagePath` generator, and `renderWorkout` logic to populate exercise cards and images dynamically.
- Add `styles.css` with a responsive design, card/grid styles, and visual theming for the tracker.
- Add many new static SVG assets under `images/exercises/*` for all exercises (three images per exercise) and update `README.md` to describe the project structure.

### Testing
- No automated tests were configured or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aee92c12cc832cb2a39204525ecde1)